### PR TITLE
make `endpoint` config work

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,7 +119,9 @@ export default {
     // if you also want to use it in production, set this to true
     // keep in mind that graphql playground has to be enabled
     enabled: process.env.NODE_ENV === "production" ? false : true,
-    // endpoint: "https://tunneled-strapi.com/graphql", // OPTIONAL - endpoint has to be accessible from the browser
+    config: {
+      // endpoint: "https://tunneled-strapi.com/graphql", // OPTIONAL - endpoint has to be accessible from the browser
+    }
   },
   // ...
 };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@creazy231/strapi-plugin-apollo-sandbox",
-  "version": "0.0.13",
+  "version": "0.0.14",
   "description": "Integrate Apollo Sandbox for a powerful GraphQL Explorer in your Strapi Admin Interface",
   "strapi": {
     "displayName": "Apollo Sandbox",

--- a/server/config/index.ts
+++ b/server/config/index.ts
@@ -8,7 +8,7 @@ export default {
         throw new TypeError("endpoint has to be a string");
       }
 
-      if (!config.endpoint.startsWith("http://") || !config.endpoint.startsWith("https://")) {
+      if (!config.endpoint.startsWith("http://") && !config.endpoint.startsWith("https://")) {
         throw new TypeError("endpoint has to be a valid URL");
       }
     }

--- a/server/config/index.ts
+++ b/server/config/index.ts
@@ -4,7 +4,7 @@ export default {
   }),
   validator: (config) => {
     if (config.endpoint) {
-      if (config.endpoint !== typeof "string") {
+      if (typeof config.endpoint !== "string") {
         throw new TypeError("endpoint has to be a string");
       }
 

--- a/server/controllers/tunnel.ts
+++ b/server/controllers/tunnel.ts
@@ -13,17 +13,23 @@ export default ({ strapi }: { strapi: Strapi }) => ({
       return ctx.throw(400, "Server port or GraphQL endpoint not found");
     }
 
-    const NODE_MAJOR_VERSION = process.versions.node.split(".")[0];
+    let url;
 
-    tunnel = await localtunnel({
-      host: "http://lt.boltapi.com",
-      port: PORT,
-      local_host: Number(NODE_MAJOR_VERSION) <= 16 ? "0.0.0.0" : "127.0.0.1",
-      allow_invalid_cert: true,
-    });
+    if (endpoint) {
+      url = endpoint;
+    } else {
+      const NODE_MAJOR_VERSION = process.versions.node.split(".")[0];
+      tunnel = await localtunnel({
+        host: "http://lt.boltapi.com",
+        port: PORT,
+        local_host: Number(NODE_MAJOR_VERSION) <= 16 ? "0.0.0.0" : "127.0.0.1",
+        allow_invalid_cert: true,
+      });
+      url = `${tunnel.url}${ENDPOINT}`,
+    }
 
     ctx.body = {
-      url: `${tunnel.url}${ENDPOINT}`,
+      url,
     };
   },
   async closeTunnel(ctx) {

--- a/server/controllers/tunnel.ts
+++ b/server/controllers/tunnel.ts
@@ -13,7 +13,7 @@ export default ({ strapi }: { strapi: Strapi }) => ({
       return ctx.throw(400, "Server port or GraphQL endpoint not found");
     }
 
-    let url;
+    let URL: string;
 
     if (endpoint) {
       url = endpoint;
@@ -25,7 +25,7 @@ export default ({ strapi }: { strapi: Strapi }) => ({
         local_host: Number(NODE_MAJOR_VERSION) <= 16 ? "0.0.0.0" : "127.0.0.1",
         allow_invalid_cert: true,
       });
-      url = `${tunnel.url}${ENDPOINT}`,
+      url = `${tunnel.url}${ENDPOINT}`;
     }
 
     ctx.body = {

--- a/server/controllers/tunnel.ts
+++ b/server/controllers/tunnel.ts
@@ -5,7 +5,7 @@ import pluginId from "../../admin/src/pluginId";
 let tunnel: localtunnel.Tunnel | null = null;
 export default ({ strapi }: { strapi: Strapi }) => ({
   async createTunnel(ctx) {
-    const endpoint = strapi.config.get(pluginId)?.endpoint;
+    const endpoint = strapi.config.get("plugin."+pluginId)?.endpoint;
     const PORT = strapi.config.get("server.port");
     const ENDPOINT = strapi.config.get("plugin.graphql.endpoint");
 

--- a/server/controllers/tunnel.ts
+++ b/server/controllers/tunnel.ts
@@ -13,7 +13,7 @@ export default ({ strapi }: { strapi: Strapi }) => ({
       return ctx.throw(400, "Server port or GraphQL endpoint not found");
     }
 
-    let URL: string;
+    let url: string;
 
     if (endpoint) {
       url = endpoint;


### PR DESCRIPTION
If `endpoint` is provided, it shouldn't create a tunnel

Fixes #4